### PR TITLE
initialization of the TestsBase class is now in place

### DIFF
--- a/C#.Net/Tests/Scenarios/Page Objects/EpamSite.cs
+++ b/C#.Net/Tests/Scenarios/Page Objects/EpamSite.cs
@@ -8,9 +8,16 @@ using static Epam.JDI.Web.Selenium.Elements.Composite.CheckPageTypes;
 
 namespace Epam.Tests.Scenarios.Page_Objects
 {
+    using Tests;
+
     [Site(Domain = "https://www.epam.com")]
     public class EpamSite
     {
+        public static void Init()
+        {
+            TestsBase.Init();
+        }
+
         [Page(Url = "/", Title = "EPAM | Software Product Development Services")]
         public static HomePage HomePage;
 

--- a/C#.Net/Tests/Scenarios/Tests/ElementsCheckTests.cs
+++ b/C#.Net/Tests/Scenarios/Tests/ElementsCheckTests.cs
@@ -7,6 +7,12 @@ namespace Epam.Tests.Scenarios.Tests
     [TestFixture]
     public class ElementsCheckTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            Init();
+        }
+
         [Test]
         public void ElementsTest_Textbox_Text()
         {

--- a/C#.Net/Tests/Scenarios/Tests/SmokeTests.cs
+++ b/C#.Net/Tests/Scenarios/Tests/SmokeTests.cs
@@ -8,6 +8,12 @@ namespace Epam.Tests.Scenarios.Tests
     [TestFixture]
     public class SmokeTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            Init();
+        }
+
         [Test]
         public void CareerTest()
         {

--- a/C#.Net/Tests/Scenarios/Tests/TestsBase.cs
+++ b/C#.Net/Tests/Scenarios/Tests/TestsBase.cs
@@ -24,10 +24,14 @@ namespace Epam.Tests.Scenarios.Tests
     {
         protected static Timer Timer;
         public static TimeSpan TestRunTime => Timer.TimePassed;
+        static bool _alreadyInitialized;
 
         [OneTimeSetUp]
-        public void Init()
+        public static void Init()
         {
+            if (_alreadyInitialized)
+                return;
+
             InitFromProperties();
             Logger.Info("Init test run");
             KillAllRunWebDrivers();
@@ -41,6 +45,8 @@ namespace Epam.Tests.Scenarios.Tests
             WebSite.Init(typeof(EpamSite));
             EpamSite.HomePage.Open();
             Logger.Info("Run Tests");
+
+            _alreadyInitialized = true;
         }
 
         [OneTimeTearDown]


### PR DESCRIPTION
If one downloads the whole epam/JDI repository, tests provided with the .NET version won't work. The initialization code is in the TestsBase class that is never called.
This pull request contains initialization added to test classes that calls the Init method.