### PR TITLE
Kill browser and web driver processes before and after test.

### DIFF
--- a/Java/JDI/jdi-uitest-web/pom.xml
+++ b/Java/JDI/jdi-uitest-web/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <selenium.version>3.0.1</selenium.version>
+        <selenium.version>3.3.1</selenium.version>
         <testng.version>6.8.1</testng.version>
         <log4j.version>1.2.17</log4j.version>
         <saucelab.version>2.1.19</saucelab.version>

--- a/Java/JDI/jdi-uitest-web/src/main/java/com/epam/jdi/uitests/web/selenium/driver/WebDriverUtils.java
+++ b/Java/JDI/jdi-uitest-web/src/main/java/com/epam/jdi/uitests/web/selenium/driver/WebDriverUtils.java
@@ -17,56 +17,40 @@ package com.epam.jdi.uitests.web.selenium.driver;
  * along with JDI. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import com.epam.commons.*;
+import org.openqa.selenium.os.*;
 
-import org.openqa.selenium.os.CommandLine;
-import org.openqa.selenium.os.WindowsUtils;
-
-import java.util.Map;
-
-import static com.epam.commons.LinqUtils.first;
-import static com.epam.commons.LinqUtils.where;
-import static com.epam.commons.TryCatchUtil.tryGetResult;
+import java.io.*;
 
 /**
  * Created by 12345 on 26.01.2015.
  */
 public final class WebDriverUtils {
-    private WebDriverUtils() { }
-    private static final String KILL = "taskkill /F /IM ";
-    public static void killAllRunWebDrivers() {
-        try {
-     /*       String line;
-            List<String> list = new ArrayList<>();
-            Process p = Runtime.getRuntime().exec
-                    (System.getenv("windir") +"\\system32\\"+"tasklist.exe");
-            BufferedReader input =
-                    new BufferedReader(new InputStreamReader(p.getInputStream()));
-            while ((line = input.readLine()) != null) {
-                list.add(line);
-            }
-            String s =first(where(list, el -> el.contains("firefox") && el.contains("-foreground")
-                    || el.contains("chromedriver")
-                    || el.contains("IEDriverServer")));
-            //for ( String serviceName : list)
-             //   Runtime.getRuntime().exec(KILL + serviceName);*/
-            String pid = getPid();
-            while (pid != null) {
-                killPID(pid);
-                pid = getPid();
-            }
-        } catch (Exception ignore) {
-            // Ignore in case of not windows Operation System or any other errors
+
+    private WebDriverUtils() {
+    }
+
+    //TODO Add OS type and current user check.
+    //TODO Try to use C/C++ Library to work with processes.
+    public static void killAllRunWebBrowsers() throws IOException {
+        switch (PropertyReader.getProperty("driver").toLowerCase()) {
+            case "chrome":
+                WindowsUtils.killByName("chromedriver.exe");
+                WindowsUtils.killByName("chrome.exe");
+                break;
+            case "firefox":
+                WindowsUtils.killByName("geckodriver.exe");
+                WindowsUtils.killByName("firefox.exe");
+                break;
+            case "ie":
+            case "internetexplorer":
+                WindowsUtils.killByName("IEDriverServer.exe");
+                WindowsUtils.killByName("iexplore.exe");
+                break;
+            case "edge":
+                WindowsUtils.killByName("MicrosoftWebDriver.exe");
+                WindowsUtils.killByName("MicrosoftEdge.exe");
+            default:
         }
-    }
-
-    private static String getPid() {
-        return first(where((Map<String, String>) tryGetResult(WindowsUtils::procMap), el -> el.getKey() != null
-                && (el.getKey().contains("firefox") && el.getKey().contains("-foreground")
-                || el.getKey().contains("chromedriver")
-                || el.getKey().contains("IEDriverServer"))));
-    }
-
-    private static void killPID(String processID) {
-        new CommandLine("taskkill", "/f", "/t", "/pid", processID).execute();
     }
 }

--- a/Java/JDI/jdi-uitest-web/src/main/java/com/epam/jdi/uitests/web/testng/testRunner/TestNGBase.java
+++ b/Java/JDI/jdi-uitest-web/src/main/java/com/epam/jdi/uitests/web/testng/testRunner/TestNGBase.java
@@ -17,19 +17,18 @@ package com.epam.jdi.uitests.web.testng.testRunner;
  * along with JDI. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import com.epam.commons.*;
+import com.epam.jdi.uitests.web.selenium.driver.*;
+import org.testng.annotations.*;
 
-import com.epam.commons.Timer;
-import com.epam.jdi.uitests.web.selenium.driver.DriverTypes;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import java.io.*;
+import java.time.*;
+import java.time.format.*;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
-import static com.epam.commons.StringUtils.LINE_BREAK;
+import static com.epam.commons.StringUtils.*;
 import static com.epam.jdi.uitests.core.settings.JDISettings.driverFactory;
 import static com.epam.jdi.uitests.core.settings.JDISettings.logger;
-import static com.epam.jdi.uitests.web.selenium.driver.WebDriverUtils.killAllRunWebDrivers;
+import static com.epam.jdi.uitests.web.selenium.driver.WebDriverUtils.*;
 import static com.epam.jdi.uitests.web.settings.WebSettings.initFromProperties;
 import static com.epam.jdi.uitests.web.settings.WebSettings.useDriver;
 
@@ -44,19 +43,31 @@ public class TestNGBase {
     }
 
     @BeforeSuite(alwaysRun = true)
-    public static void jdiSetUp() throws Exception {
+    public static void jdiSetUp() throws IOException {
         initFromProperties();
         logger.info("Init test run");
-        killAllRunWebDrivers();
+
+        String browserKill = PropertyReader.getProperty("browser.kill.before");
+        if (browserKill == null || browserKill.equals("true")) {
+            killAllRunWebBrowsers();
+        }
         if (!driverFactory.hasDrivers())
             useDriver(DriverTypes.CHROME);
         timer = new Timer();
     }
 
     @AfterSuite(alwaysRun = true)
-    public static void jdiTearDown() {
-        logger.info("Test run finished. " + LINE_BREAK + "Total test run time: "
-                + new SimpleDateFormat("HH:mm:ss.S").format(new Date(21 * 3600000 + getTestRunTime())));
-        killAllRunWebDrivers();
+    public static void jdiTearDown() throws IOException {
+        LocalDateTime date = Instant.ofEpochMilli(21 * 3600000 + getTestRunTime())
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+        String formattedTime = DateTimeFormatter.ofPattern("HH:mm:ss.S").format(date);
+
+        logger.info("Test run finished. " + LINE_BREAK + "Total test run time: " + formattedTime);
+
+        String browserKill = PropertyReader.getProperty("browser.kill.after");
+        if (browserKill == null || browserKill.equals("true")) {
+            killAllRunWebBrowsers();
+        }
     }
 }

--- a/Java/Tests/jdi-httpTests/src/test/resources/test.properties
+++ b/Java/Tests/jdi-httpTests/src/test/resources/test.properties
@@ -1,3 +1,5 @@
+browser.kill.before=true
+browser.kill.after=true
 driver=chrome
 #drivers.version=2.23
 timeout.wait.element=10

--- a/Java/Tests/jdi-uitest-cucumbertests/src/test/java/cucmberTests/stepdefs/baseCucumberScenario.java
+++ b/Java/Tests/jdi-uitest-cucumbertests/src/test/java/cucmberTests/stepdefs/baseCucumberScenario.java
@@ -8,6 +8,8 @@ import com.epam.web.matcher.verify.Verify;
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
 
+import java.io.*;
+
 import static com.epam.jdi.uitests.core.settings.JDISettings.initFromProperties;
 import static com.epam.jdi.uitests.core.settings.JDISettings.logger;
 import static com.epam.jdi.uitests.testing.unittests.pageobjects.EpamJDISite.homePage;
@@ -38,11 +40,9 @@ public class baseCucumberScenario {
         }
     }
 
-
     @After
-    public void after(){
+    public void after() throws IOException {
         TestNGBase.jdiTearDown();
         Verify.getFails();
     }
-
 }

--- a/Java/Tests/jdi-uitest-cucumbertests/src/test/resources/test.properties
+++ b/Java/Tests/jdi-uitest-cucumbertests/src/test/resources/test.properties
@@ -1,3 +1,5 @@
+browser.kill.before=true
+browser.kill.after=true
 driver=chrome
 domain=https://jdi-framework.github.io/tests
 timeout.wait.element=5

--- a/Java/Tests/jdi-uitest-tutorialtests/src/test/java/com/epam/jdi/uitests/testing/TestsBase.java
+++ b/Java/Tests/jdi-uitest-tutorialtests/src/test/java/com/epam/jdi/uitests/testing/TestsBase.java
@@ -6,8 +6,10 @@ import com.epam.jdi.uitests.web.testng.testRunner.TestNGBase;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 
+import java.io.*;
+
 import static com.epam.jdi.uitests.core.settings.JDISettings.logger;
-import static com.epam.jdi.uitests.web.selenium.driver.WebDriverUtils.killAllRunWebDrivers;
+import static com.epam.jdi.uitests.web.selenium.driver.WebDriverUtils.killAllRunWebBrowsers;
 
 /**
  * Created by Roman_Iovlev on 7/13/2015.
@@ -21,7 +23,7 @@ public abstract class TestsBase extends TestNGBase {
     }
 
     @AfterSuite(alwaysRun = true)
-    public static void tearDown() {
-        killAllRunWebDrivers();
+    public static void tearDown() throws IOException {
+        killAllRunWebBrowsers();
     }
 }

--- a/Java/Tests/jdi-uitest-tutorialtests/src/test/resources/test.properties
+++ b/Java/Tests/jdi-uitest-tutorialtests/src/test/resources/test.properties
@@ -1,3 +1,6 @@
+browser.kill.before=true
+browser.kill.after=true
+
 driver=chrome
 #drivers.version=2.23
 timeout.wait.element=10

--- a/Java/Tests/jdi-uitest-web-examples/src/test/resources/test.properties
+++ b/Java/Tests/jdi-uitest-web-examples/src/test/resources/test.properties
@@ -1,5 +1,8 @@
 domain=http://www.imdb.com
 
+browser.kill.before=true
+browser.kill.after=true
+
 driver=chrome
 driver.getLatest=true
 

--- a/Java/Tests/jdi-uitest-webtests/src/test/resources/test.properties
+++ b/Java/Tests/jdi-uitest-webtests/src/test/resources/test.properties
@@ -1,3 +1,5 @@
+browser.kill.before=true
+browser.kill.after=true
 driver=chrome
 domain=https://jdi-framework.github.io/tests
 timeout.wait.element=5


### PR DESCRIPTION
В test.properties добавлены две переменные: browser.kill.before и browser.kill.after. Они полезны если во время разработки нужно сохранять свои вкладки браузера.