### PR TITLE
Possibility to cascade load properties from multiple config files.

### DIFF
--- a/Java/JDI/jdi-commons/src/main/java/com/epam/commons/PropertyReader.java
+++ b/Java/JDI/jdi-commons/src/main/java/com/epam/commons/PropertyReader.java
@@ -45,6 +45,10 @@ public final class PropertyReader {
         } catch (Exception ex) {
             if (inputStream != null) inputStream.close();
         }
+        if(properties.getProperty("config_file")!=null){
+            Properties additionalProperties = getProperties(properties.getProperty("config_file"));
+            properties.putAll(additionalProperties);
+        }
         return properties;
     }
 


### PR DESCRIPTION
If PropertyReader finds non-empty 'config_file' property in test.properties, it would retrieve properties from next file and add these properties to existing ones.
- Properties from test.properties can be overridden
- It is possible to chain multiple properties files if needed