### PR TITLE
fix AppiumDriverFactory: remove window().maximize() since it doesn't …

### DIFF
--- a/Java/JDI/jdi-uitest-mobile/src/main/java/com/epam/jdi/uitests/mobile/appium/driver/AppiumDriverFactory.java
+++ b/Java/JDI/jdi-uitest-mobile/src/main/java/com/epam/jdi/uitests/mobile/appium/driver/AppiumDriverFactory.java
@@ -192,7 +192,6 @@ public class AppiumDriverFactory implements IDriver<WebDriver> {
             runDrivers.add(driverName, resultDriver);
             if (resultDriver == null)
                 throw exception("Can't get Webdriver '%s'. This Driver name not registered", driverName);
-            resultDriver.manage().window().maximize();
             resultDriver.manage().timeouts().implicitlyWait(timeouts.getCurrentTimeoutSec(), SECONDS);
             return resultDriver;
         } catch (Exception ex) {


### PR DESCRIPTION
…make sense for appium and appium returns 501 for such request

Appium returns 501 and session ends with error, since window/maximize is not implemented in appium.
```
[HTTP] --> POST /wd/hub/session/1e86e070-5335-405e-9bf1-3eb75512ff88/window/current/maximize {"windowHandle":"current","handle":"current"}
[debug] [MJSONWP] Calling AppiumDriver.maximizeWindow() with args: ["current","1e86e070-5335-405e-9bf1-3eb75512ff88"]
[HTTP] <-- POST /wd/hub/session/1e86e070-5335-405e-9bf1-3eb75512ff88/window/current/maximize 501 43 ms - 122
```