### PR TITLE
Added functionality, that searches for a match on a web browser layout

### DIFF
--- a/Java/JDI/jdi-uitest-web/pom.xml
+++ b/Java/JDI/jdi-uitest-web/pom.xml
@@ -80,6 +80,11 @@
             <artifactId>selenide</artifactId>
             <version>LATEST</version>
         </dependency>
+        <dependency>
+            <groupId>com.sikulix</groupId>
+            <artifactId>sikulixapi</artifactId>
+            <version>1.1.0</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/Java/JDI/jdi-uitest-web/src/main/java/com/epam/jdi/uitests/web/selenium/utils/LayoutVerifier.java
+++ b/Java/JDI/jdi-uitest-web/src/main/java/com/epam/jdi/uitests/web/selenium/utils/LayoutVerifier.java
@@ -1,0 +1,45 @@
+package com.epam.jdi.uitests.web.selenium.utils;
+
+/*
+ * Uses Sikuli API for comparing provided images with specified web browser layout.
+ */
+
+import org.sikuli.script.App;
+import org.sikuli.script.Match;
+import org.sikuli.script.Region;
+
+import java.util.*;
+import static com.epam.jdi.uitests.core.settings.JDISettings.driverFactory;
+
+public class LayoutVerifier {
+
+    private static final Set<String> EXTENSIONS = new HashSet<>(Arrays.asList(".jpg", ".jpeg", ".png"));
+
+    /**
+     * Verifies that provided files are in .jpg, .jpeg or .png formats.
+     * This is a kind of compulsory measure, as Sikuli handles non-image types incorrectly.
+     *
+     * @param  pathToImage path to image: C:/Screenshots/img1.jpeg
+     */
+    public static boolean verifyImageFormat(String pathToImage) {
+        int dot = pathToImage.lastIndexOf(".");
+        if (dot > 0) {
+            String ending = pathToImage.substring(dot);
+            return EXTENSIONS.contains(ending.toLowerCase());
+        }
+        return false;
+    }
+
+    /**
+     * Returns Match object, if a match was found.
+     *
+     * @return null, if match was not found.
+     */
+    public static Match findMatch(String pathToFile) {
+        String browserName = driverFactory.currentDriverName();
+        assert !browserName.isEmpty();
+        App.focus(browserName);
+        Region r = App.focusedWindow();
+        return r.exists(pathToFile);
+    }
+}


### PR DESCRIPTION
two methods were added for WebPage class:  
1) boolean verifyLayout(String pathToFile)  - verify matches on a layout for a single image;
2) List<String> verifyLayoutMatches(String pathToDir) verify matches on a layout for all files in a dir.

Sikuli method that searches for matches is not thread safe and doesn't work in parallel mode, so verifyLayoutMatches is rather slow.
